### PR TITLE
Parse wiki page markup for exact match from archive

### DIFF
--- a/src/main/java/de/zuellich/offlinewiktionary/core/WiktionaryApp.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/WiktionaryApp.java
@@ -1,6 +1,8 @@
 package de.zuellich.offlinewiktionary.core;
 
+import de.zuellich.offlinewiktionary.core.archive.WiktionaryReader;
 import de.zuellich.offlinewiktionary.core.gui.WiktionaryModel;
+import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
 import java.io.File;
 import javafx.application.Application;
 import javafx.scene.Parent;
@@ -15,12 +17,12 @@ import javafx.stage.Stage;
 
 public class WiktionaryApp extends Application {
 
-  private final WiktionaryModel model = new WiktionaryModel();
+  private final WiktionaryModel model = new WiktionaryModel(new WiktionaryReader(null));
 
   private String searchHandler(String query) {
     System.out.println("You searched for: " + query);
     System.out.println("Result:\n" + model.lookupDefinition(query));
-    return model.lookupDefinition(query).orElse("Nothing found.");
+    return model.lookupDefinition(query).map(WikiPage::text).orElse("Nothing found.");
   }
 
   private Parent createContent(Stage primaryStage) {
@@ -52,7 +54,7 @@ public class WiktionaryApp extends Application {
         });
 
     Text definition = new Text("");
-    definition.setWrappingWidth(200);
+    definition.setWrappingWidth(800);
 
     TextField search = new TextField();
     search.disableProperty().bind(model.isReadyProperty().not());

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/SeekEntry.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/SeekEntry.java
@@ -5,6 +5,11 @@ import java.util.Objects;
 /** Holds information where to find a page. */
 public record SeekEntry(long bytesToSeek, int articleId, String title)
     implements Comparable<SeekEntry> {
+
+  public static SeekEntry forQuery(String query) {
+    return new SeekEntry(0, 0, query);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/WikiPageSAXParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/WikiPageSAXParser.java
@@ -7,9 +7,10 @@ import java.util.Stack;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 
+/** Parse {@link WikiPage}s from XML. */
 public class WikiPageSAXParser extends DefaultHandler {
 
-  private HashMap<String, WikiPage> result = new HashMap<>();
+  private HashMap<Integer, WikiPage> result = new HashMap<>();
 
   private final Stack<String> lastStartElement = new Stack<>();
   private WikiPage.Builder current = new WikiPage.Builder();
@@ -51,16 +52,16 @@ public class WikiPageSAXParser extends DefaultHandler {
         break;
       case "id":
         if (Objects.equals(lastStartElement.peek(), "page")) {
-          current.setId(elementValue.toString());
+          current.setId(Integer.parseInt(elementValue.toString()));
         }
         break;
       case "text":
-        if (Objects.equals(lastStartElement.peek(), "page")) {
+        if (Objects.equals(lastStartElement.peek(), "revision")) {
           current.setText(elementValue.toString());
         }
         break;
       case "format":
-        if (Objects.equals(lastStartElement.peek(), "page")) {
+        if (Objects.equals(lastStartElement.peek(), "revision")) {
           current.setFormat(elementValue.toString());
         }
         break;
@@ -72,7 +73,7 @@ public class WikiPageSAXParser extends DefaultHandler {
     }
   }
 
-  public HashMap<String, WikiPage> getResult() {
+  public HashMap<Integer, WikiPage> getResult() {
     return new HashMap<>(result);
   }
 }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReader.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReader.java
@@ -1,0 +1,49 @@
+package de.zuellich.offlinewiktionary.core.archive;
+
+import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import org.xml.sax.SAXException;
+
+/** Wraps the {@link WikiPageSAXParser} to parse wiki pages from a compressed archive. */
+public class WiktionaryArchiveReader {
+  private SAXParser parser;
+
+  public WiktionaryArchiveReader() {}
+
+  private SAXParser getParser() {
+    if (parser == null) {
+      SAXParserFactory factory = SAXParserFactory.newInstance();
+      try {
+        parser = factory.newSAXParser();
+      } catch (ParserConfigurationException | SAXException e) {
+        throw new RuntimeException("Something went wrong initializing the SAXParser");
+      }
+    }
+
+    return parser;
+  }
+
+  public HashMap<Integer, WikiPage> parse(InputStream toWrap) throws IOException, SAXException {
+    final WikiPageSAXParser wikiPageSAXParser = new WikiPageSAXParser();
+    InputStream wrappedStream =
+        new SequenceInputStream(
+            Collections.enumeration(
+                Arrays.asList(
+                    new ByteArrayInputStream("<root>".getBytes(StandardCharsets.UTF_8)),
+                    toWrap,
+                    new ByteArrayInputStream("</root>".getBytes(StandardCharsets.UTF_8)))));
+    getParser().parse(wrappedStream, wikiPageSAXParser);
+
+    return wikiPageSAXParser.getResult();
+  }
+}

--- a/src/main/java/de/zuellich/offlinewiktionary/core/wiki/WikiPage.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/wiki/WikiPage.java
@@ -1,10 +1,10 @@
 package de.zuellich.offlinewiktionary.core.wiki;
 
 /** Basic data for Wiki pages and a Builder utility for incremental parsing. */
-public record WikiPage(String title, String id, String format, String text) {
+public record WikiPage(String title, Integer id, String format, String text) {
   public static class Builder {
     private String title;
-    private String id;
+    private Integer id;
     private String format;
     private String text;
 
@@ -12,7 +12,7 @@ public record WikiPage(String title, String id, String format, String text) {
       this.title = title;
     }
 
-    public void setId(String id) {
+    public void setId(Integer id) {
       this.id = id;
     }
 

--- a/src/test/java/de/zuellich/offlinewiktionary/core/archive/Fixtures.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/archive/Fixtures.java
@@ -1,0 +1,82 @@
+package de.zuellich.offlinewiktionary.core.archive;
+
+public class Fixtures {
+  // https://en.wiktionary.org/wiki/Special:Export/Peace
+  private static final String PEACE_PAGE =
+      """
+            <page>
+                <title>Peace</title>
+                <ns>0</ns>
+                <id>6110313</id>
+                <revision>
+                    <id>71008712</id>
+                    <parentid>71008708</parentid>
+                    <timestamp>2023-01-20T20:43:28Z</timestamp>
+                    <contributor>
+                        <username>Donnanz</username>
+                        <id>1154150</id>
+                    </contributor>
+                    <minor/>
+                    <comment>/* Proper noun */</comment>
+                    <model>wikitext</model>
+                    <format>text/x-wiki</format>
+                    <text bytes="676" xml:space="preserve">
+                        {{also|peace}} ==English== {{wp|Peace (disambiguation)}} ===Proper noun=== {{en-prop|~|Peaces}} # {{surname|en}}. # {{given name|en|female}} # The {{w|Municipal District of Peace No. 135}}, {{place|en|a=a|municipal district|in north-west|p/Alberta|c/Canada}}. ====Statistics==== * According to the 2010 United States Census, ''Peace'' is the 4022<sup>nd</sup> most common surname in the United States, belonging to 8841 individuals. ''Peace'' is most common among White (70.06%) and Black/African American (23.87%) individuals. ===Noun=== {{en-noun}} # {{lb|en|numismatic slang}} {{clip of|en|{{w|Peace dollar}}}} {{cln|en|numismatic slang}} {{c|en|Coins|United States}}
+                    </text>
+                    <sha1>cwwxclxaol837q9a3t0mspzv1ej9b3u</sha1>
+                </revision>
+            </page>""";
+  // From https://en.wiktionary.org/wiki/Special:Export/love
+  public static final String SIMPLE_PAGE =
+      """
+            <page>
+                <title>love</title>
+                <ns>0</ns>
+                <id>2682</id>
+                <revision>
+                  <id>79034193</id>
+                  <parentid>78503293</parentid>
+                  <timestamp>2024-04-24T22:13:52Z</timestamp>
+                  <contributor>
+                    <username>Adelpine</username>
+                    <id>472128</id>
+                  </contributor>
+                  <comment>Correcting some IPA pronunciations and adding speakers to one of them</comment>
+                  <model>wikitext</model>
+                  <format>text/x-wiki</format>
+                  <text bytes="24072" xml:space="preserve">{{also|Love|LoVe|løve|lové|lóve|lóvé|lőve|лове}}
+                    ==English==
+                    {{wikipedia}}
+
+                    ===Alternative forms===
+                    * {{alter|en|loue||obsolete typography}}
+                    * {{alter|en|luv}}
+
+                    ===Pronunciation===
+                    * {{enPR|lŭv}}
+                    ** {{a|RP|GA|CA}} {{IPA|en|/lʌv/}}
+                    *** {{audio|en|En-uk-love.ogg|Audio (RP)}}
+                    *** {{audio|en|En-us-love.ogg|Audio (GA)}}
+                    ** {{a|Australia}} {{IPA|en|/lav/|[läv~lɐv]}}
+                    ** {{a|India}} {{IPA|en|/lʌv/|[lɘʋ]|[lɘv]}}
+                    ** {{a|Northern England|Ireland}} {{IPA|en|/lʊv/}}
+                    * {{rhymes|en|ʌv|s=1}}
+
+                    ===Etymology 1===
+                    {{root|en|ine-pro|*lewbʰ-|id=love}}
+                    From {{inh|en|enm|love}}, {{m|enm|luve}}, from {{inh|en|ang|lufu}}, from {{inh|en|gmw-pro|*lubu}}, from {{inh|en|gem-pro|*lubō}}, from {{der|en|ine-pro|*lewbʰ-|t=love, care, desire}}.
+
+                    The ''close of a letter'' sense is presumably a truncation of ''With love'' or the like.
+
+                    The verb is from {{inh|en|enm|loven}}, {{m|enm|luvien}}, from {{inh|en|ang|lufian|t=to love}}, from {{inh|en|gmw-pro|*lubōn|t=to love}}, derived from the noun.
+
+                    Eclipsed non-native {{noncog|en|amour|t=love}}, borrowed from {{noncog|fr|amour|t=love}}.
+
+                    [Rest is omitted for testing]
+                    </text>
+                    <sha1>jzyafjzm9z4x2hse0fi1w5r9grm3h4x</sha1>
+                </revision>
+            </page>""";
+
+  public static final String CONCATENATED_PAGES = PEACE_PAGE + SIMPLE_PAGE;
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/archive/StaticWiktionaryReader.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/archive/StaticWiktionaryReader.java
@@ -1,0 +1,21 @@
+package de.zuellich.offlinewiktionary.core.archive;
+
+import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
+import java.util.Optional;
+
+/**
+ * Very simple class to mock WiktionaryReader behaviour without having to use a Mocking framework.
+ */
+public class StaticWiktionaryReader extends WiktionaryReader {
+  private final Optional<WikiPage> staticResult;
+
+  public StaticWiktionaryReader(Optional<WikiPage> staticResult) {
+    super(null);
+    this.staticResult = staticResult;
+  }
+
+  @Override
+  public Optional<WikiPage> retrieve(SeekEntry entry) {
+    return staticResult;
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReaderTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReaderTest.java
@@ -1,0 +1,48 @@
+package de.zuellich.offlinewiktionary.core.archive;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import javax.xml.parsers.ParserConfigurationException;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.SAXException;
+
+class WiktionaryArchiveReaderTest {
+
+  @Test
+  public void testCanParseSimplePage()
+      throws ParserConfigurationException, SAXException, IOException {
+    final ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(Fixtures.SIMPLE_PAGE.getBytes(StandardCharsets.UTF_8));
+
+    final WiktionaryArchiveReader wiktionaryArchiveReader = new WiktionaryArchiveReader();
+
+    final HashMap<Integer, WikiPage> result = wiktionaryArchiveReader.parse(inputStream);
+    assertEquals(1, result.size());
+    final WikiPage pageResult = result.get(2682);
+    assertNotNull(pageResult);
+    assertEquals("love", pageResult.title());
+    assertEquals(2682, pageResult.id());
+    assertEquals("text/x-wiki", pageResult.format());
+    assertTrue(pageResult.text().startsWith("{{also|Love|LoVe"));
+    assertEquals(1269, pageResult.text().length());
+  }
+
+  @Test
+  public void testCanParseMultipleConcatenatedPages()
+      throws ParserConfigurationException, SAXException, IOException {
+    final ByteArrayInputStream inputStream =
+        new ByteArrayInputStream(Fixtures.CONCATENATED_PAGES.getBytes(StandardCharsets.UTF_8));
+
+    final WiktionaryArchiveReader wiktionaryArchiveReader = new WiktionaryArchiveReader();
+    final HashMap<Integer, WikiPage> result = wiktionaryArchiveReader.parse(inputStream);
+
+    assertEquals(2, result.size());
+    assertTrue(result.containsKey(6110313));
+    assertTrue(result.containsKey(2682));
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/gui/WiktionaryModelTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/gui/WiktionaryModelTest.java
@@ -1,0 +1,42 @@
+package de.zuellich.offlinewiktionary.core.gui;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.zuellich.offlinewiktionary.core.archive.SeekEntry;
+import de.zuellich.offlinewiktionary.core.archive.StaticWiktionaryReader;
+import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
+import java.util.Optional;
+import java.util.TreeSet;
+import org.junit.jupiter.api.Test;
+
+class WiktionaryModelTest {
+
+  @Test
+  public void testMakeSureToMatchTitleOfSeekEntry() {
+    // We return a WikiPage to ensure the test fails if logic is incorrect, avoids setting up a Mock
+    // framework for now
+    var wiktionaryMock =
+        new StaticWiktionaryReader(Optional.of(new WikiPage("Never return this", -1, "x", "x")));
+    var model = new WiktionaryModel(wiktionaryMock);
+
+    // GIVEN we have a definition for gerkin
+    var definition = new TreeSet<SeekEntry>();
+    definition.add(new SeekEntry(0, 1, "gerkin"));
+    model.setDefinitions(definition);
+
+    // WHEN we search for garkin
+    Optional<WikiPage> result = model.lookupDefinition("garkin");
+    // THEN we don't want to find gerkin
+    assertTrue(result.isEmpty());
+
+    // WHEN we search for gfrkin
+    result = model.lookupDefinition("gfrkin");
+    // THEN we don't want to find gfrkin
+    assertTrue(result.isEmpty());
+
+    // WHEN we search for gerkin
+    result = model.lookupDefinition("gerkin");
+    // THEN we do get a call to the wiktionary reader
+    assertTrue(result.isPresent());
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/resolution/AdjacentResolutionStrategyTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/resolution/AdjacentResolutionStrategyTest.java
@@ -2,6 +2,7 @@ package de.zuellich.offlinewiktionary.core.resolution;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import de.zuellich.offlinewiktionary.core.archive.WiktionaryReader;
 import de.zuellich.offlinewiktionary.core.exception.NoArchiveFoundException;
 import de.zuellich.offlinewiktionary.core.gui.WiktionaryModel;
 import java.net.URISyntaxException;
@@ -14,7 +15,7 @@ class AdjacentResolutionStrategyTest {
 
   @Test
   public void testThrowsIfNoArchiveIsFoundAdjacent() {
-    final var model = new WiktionaryModel();
+    final var model = new WiktionaryModel(new WiktionaryReader(null));
     try {
       final URL resourceURL =
           AdjacentResolutionStrategyTest.class.getResource(
@@ -33,7 +34,7 @@ class AdjacentResolutionStrategyTest {
 
   @Test
   public void testCanFindAdjacentArchive() {
-    final var model = new WiktionaryModel();
+    final var model = new WiktionaryModel(new WiktionaryReader(null));
     try {
       final URL resourceURL =
           AdjacentResolutionStrategyTest.class.getResource(


### PR DESCRIPTION
If we can find an exact match of the user's query in our index we parse the page from the archive.

Known issues:
- Parsing the archive is not optimized (e.g. we probably read more than we have to).