### PR TITLE
Indentation and italic markup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Part of the project implements a PEG-based parser to convert MediaWiki markup to
 page content in the app. Belows is the implemented grammar that supports only a tiny subset:
 
 ```text
-Markup              <- Headline / TextContent
+Markup              <- Headline / Indent / TextContent
 TextContent         <- Macro / Link / Text*
 
 Headline            <- Headline2Start TextContent+ Headline2End
@@ -23,6 +23,8 @@ Link                <- LinkStart LinkText ('|' LinkText)? LinkEnd (! ' ' & utf-8
 LinkStart           <- '[['
 LinkEnd             <- ']]'
 LinkText            <- !'|' & !LinkEnd & utf-8 symbol
+
+Indent              <- ':'+ TextContent
 
 Text                <-  (!MacroStart & !MacroEnd 
                         & !HeadlineStart & !HeadlineEnd 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Part of the project implements a PEG-based parser to convert MediaWiki markup to
 page content in the app. Belows is the implemented grammar that supports only a tiny subset:
 
 ```text
-Markup              <- Headline / Indent / TextContent
+Markup              <- Headline / Indent / Italic / TextContent
 TextContent         <- Macro / Link / Text*
+
+Italic              <- '\'\'' TextContent+ '\'\''
 
 Headline            <- Headline2Start TextContent+ Headline2End
 HeadlineStart       <- '=' '='+

--- a/build.gradle
+++ b/build.gradle
@@ -48,4 +48,11 @@ test {
     useJUnitPlatform()
 }
 
+task testParserOnly(type: Test) {
+    description "Only run the tests related to the wiki text parser."
+    useJUnitPlatform {
+        includeTags("MarkupParser")
+    }
+}
+
 mainClassName = 'de.zuellich.offlinewiktionary.core.WiktionaryApp'

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
@@ -30,6 +30,7 @@ public class WikiTextFlow extends TextFlow {
       switch (token.getType()) {
         case LINK -> result.add(linkNode((LinkToken) token));
         case HEADING -> result.add(headingNode((HeadingToken) token));
+        case INDENT -> result.add(indentNode((IndentToken) token));
         default -> result.add(textNode((TextToken) token));
       }
     }
@@ -60,6 +61,12 @@ public class WikiTextFlow extends TextFlow {
     Text result = new Text();
     result.setText(token.value());
     result.setFont(Font.font(12));
+    return result;
+  }
+
+  private Text indentNode(IndentToken token) {
+    Text result = new Text();
+    result.setText("\t".repeat(Math.min(token.level(), 10)));
     return result;
   }
 }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/IndentToken.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/IndentToken.java
@@ -1,0 +1,8 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+public record IndentToken(int level) implements MarkupToken {
+  @Override
+  public MarkupTokenType getType() {
+    return MarkupTokenType.INDENT;
+  }
+}

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/ItalicToken.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/ItalicToken.java
@@ -1,0 +1,20 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import java.util.List;
+
+public record ItalicToken(List<MarkupToken> value) implements MarkupToken {
+
+  public ItalicToken(List<MarkupToken> value) {
+    this.value = List.copyOf(value);
+  }
+
+  @Override
+  public List<MarkupToken> value() {
+    return List.copyOf(this.value);
+  }
+
+  @Override
+  public MarkupTokenType getType() {
+    return MarkupTokenType.ITALIC;
+  }
+}

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
@@ -28,6 +28,18 @@ public class MarkupParser {
   private final Stack<Integer> snapshot = new Stack<>();
   private final List<Supplier<MarkupToken>> tokenParserPriority;
 
+  /**
+   * Helper function for brevity in tests. Do allow for dependency injection consider the
+   * straightforward way and create a new instance in the constructor.
+   *
+   * @param input String to parse
+   * @return A list of parsed tokens.
+   */
+  public static List<MarkupToken> parseString(String input) {
+    var parser = new MarkupParser();
+    return parser.parse(input);
+  }
+
   public MarkupParser() {
     tokenParserPriority =
         List.of(this::parseIndent, this::parseHeading, this::parseLink, this::parseText);

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
@@ -77,6 +77,21 @@ public class MarkupParser {
     return new TextToken(value.toString());
   }
 
+  /**
+   * Check if the previous character matches c. If pointer has not moved yet, then false is
+   * returned.
+   *
+   * @param c
+   * @return false if character is not matching, or pointer out of bounds.
+   */
+  private boolean currentCharMatches(char c) {
+    if (pointer < 0) {
+      return false;
+    }
+
+    return this.input[pointer] == c;
+  }
+
   /** Look at next character, but don't advance pointer */
   private char peekNextChar() {
     if (pointer == this.input.length - 1) {
@@ -247,12 +262,11 @@ public class MarkupParser {
   }
 
   private IndentToken parseIndent() {
-    if (peekNextChar() != ':') {
-      return null;
+    if ((currentCharMatches('\n') || pointer == -1) && peekNextChar() == ':') {
+      int level = consumeMatching(':');
+      return new IndentToken(level);
     }
-
-    int level = consumeMatching(':');
-    return new IndentToken(level);
+    return null;
   }
 
   private Optional<MarkupToken> nextToken() {

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupTokenType.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupTokenType.java
@@ -3,7 +3,8 @@ package de.zuellich.offlinewiktionary.core.markup;
 public enum MarkupTokenType {
   HEADING,
   INDENT,
+  ITALIC,
   LINK,
   TEXT,
-  NULL;
+  NULL,
 }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupTokenType.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupTokenType.java
@@ -2,6 +2,7 @@ package de.zuellich.offlinewiktionary.core.markup;
 
 public enum MarkupTokenType {
   HEADING,
+  INDENT,
   LINK,
   TEXT,
   NULL;

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserHeadlineTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserHeadlineTest.java
@@ -1,0 +1,23 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.assertHeadline;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("MarkupParser")
+public class MarkupParserHeadlineTest {
+
+  @Test
+  public void canParseSimpleHeadline() {
+    String input = "==Headline==";
+    final MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse(input);
+    assertEquals(1, result.size());
+
+    MarkupToken parseToken = result.getFirst();
+    assertHeadline(parseToken, 2, "Headline");
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserIndentTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserIndentTest.java
@@ -1,0 +1,59 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.*;
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.assertText;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("MarkupParser")
+public class MarkupParserIndentTest {
+
+  @Test
+  public void canParseSimpleIndents() {
+    final MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse(": Indent Level 1");
+    assertTokensStrict(result, List.of(indent(1), text(" Indent Level 1")));
+
+    result = parser.parse(":: Indent Level 2");
+    assertTokensStrict(result, List.of(indent(2), text(" Indent Level 2")));
+
+    result = parser.parse("::: Indent Level 3");
+    assertTokensStrict(result, List.of(indent(3), text(" Indent Level 3")));
+  }
+
+  @Test
+  public void canCombineWithOtherMarkup() {
+    final MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse(": Another [[Example]]");
+    assertTokensStrict(result, List.of(indent(1), text(" Another "), link("Example")));
+
+    result = parser.parse("""
+                : Line 1
+                : Line 2 [[WithLink]]""");
+    assertTokensStrict(
+        result,
+        List.of(indent(1), text(" Line 1\n"), indent(1), text(" Line 2"), link("WithLink")));
+
+    // We mostly encounter indent with a space in between the colon and text,
+    // but these forms are also possible:
+    result = parser.parse(":[[Link]]");
+    assertTokensStrict(result, List.of(indent(1), link("Link")));
+
+    result = parser.parse("Here : is no indent!");
+    assertTokensStrict(result, List.of(text("Here : is no indent!")));
+  }
+
+  @Test
+  public void respectWhitespace() {
+    final MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse("::More");
+    assertIndent(result.get(0), 2);
+    assertText(result.get(1), "More");
+
+    result = parser.parse(":  With extra whitespace");
+    assertIndent(result.get(0), 1);
+    assertText(result.get(1), "  With extra whitespace");
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserIndentTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserIndentTest.java
@@ -34,7 +34,7 @@ public class MarkupParserIndentTest {
                 : Line 2 [[WithLink]]""");
     assertTokensStrict(
         result,
-        List.of(indent(1), text(" Line 1\n"), indent(1), text(" Line 2"), link("WithLink")));
+        List.of(indent(1), text(" Line 1\n"), indent(1), text(" Line 2 "), link("WithLink")));
 
     // We mostly encounter indent with a space in between the colon and text,
     // but these forms are also possible:

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserItalicTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserItalicTest.java
@@ -1,0 +1,28 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("MarkupParser")
+public class MarkupParserItalicTest {
+
+  @Test
+  public void canParseSimpleItalics() {
+    List<MarkupToken> result = MarkupParser.parseString("''hello world''");
+    assertTokensStrict(result, List.of(italic(List.of(text("hello world")))));
+    result = MarkupParser.parseString("This is ''some'' text!");
+    assertTokensStrict(
+        result, List.of(text("This is "), italic(List.of(text("some"))), text(" text!")));
+  }
+
+  @Test
+  public void canCombineWithOtherMarkup() {
+    List<MarkupToken> result = MarkupParser.parseString("''[[Link]]''");
+    assertTokensStrict(result, List.of(italic(List.of(link("Link")))));
+    result = MarkupParser.parseString("This is ''[[more]]''!");
+    assertTokensStrict(result, List.of(text("This is "), italic(List.of(link("more"))), text("!")));
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserLinkTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserLinkTest.java
@@ -1,0 +1,68 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.assertLink;
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.assertText;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("MarkupParser")
+public class MarkupParserLinkTest {
+
+  @Test
+  public void canParseLink() {
+    String input = "[[Link]]";
+    final MarkupParser parser = new MarkupParser();
+    final List<MarkupToken> result = parser.parse(input);
+    assertEquals(1, result.size());
+    assertLink(result.get(0), "Link", "Link");
+  }
+
+  @Test
+  public void canParsePipedLink() {
+    String input = "[[Link|Label]]";
+    final MarkupParser parser = new MarkupParser();
+    final List<MarkupToken> result = parser.parse(input);
+    assertEquals(1, result.size());
+    assertLink(result.get(0), "Label", "Link");
+  }
+
+  @Test
+  public void canParseWordEndingLinks() {
+    String input = "[[Link]]here But this is text!";
+    final MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse(input);
+    assertEquals(2, result.size());
+    assertLink(result.get(0), "Linkhere", "Link");
+    assertText(result.get(1), " But this is text!");
+
+    result = parser.parse("[[Link]]. But not text.");
+    assertEquals(2, result.size());
+    assertLink(result.get(0), "Link", "Link");
+    assertText(result.get(1), ". But not text.");
+
+    result = parser.parse("[[Link|Label]], but not text.");
+    assertEquals(2, result.size());
+    assertLink(result.get(0), "Label", "Link");
+    assertText(result.get(1), ", but not text.");
+
+    result = parser.parse("[[Link|Label]], [[Another|Label2]].");
+    assertEquals(4, result.size());
+    assertLink(result.get(0), "Label", "Link");
+    assertText(result.get(1), ", ");
+    assertLink(result.get(2), "Label2", "Another");
+    assertText(result.get(3), ".");
+  }
+
+  @Test
+  public void canParseMacrosWithLinkArgument() {
+    final MarkupParser parser = new MarkupParser();
+    final List<MarkupToken> result = parser.parse("{{Macro|[[Link|Label]]}}");
+    assertEquals(3, result.size());
+    assertText(result.get(0), "{{Macro|");
+    assertLink(result.get(1), "Label", "Link");
+    assertText(result.get(2), "}}");
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTest.java
@@ -5,104 +5,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.Duration;
 import java.util.List;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("MarkupParser")
 class MarkupParserTest {
-
-  @Test
-  public void canParseSimpleText() {
-    MarkupParser parser = new MarkupParser();
-    List<MarkupToken> result = parser.parse("Hello World!");
-    assertEquals(1, result.size());
-    assertText(result.get(0), "Hello World!");
-
-    result = parser.parse("Here : is no indent!");
-    assertEquals(1, result.size());
-    assertText(result.get(0), "Here : is no indent!");
-
-    result =
-        parser.parse("""
-                We can also parse
-
-                multi-line text.""");
-    assertEquals(3, result.size());
-    assertText(result.get(0), "We can also parse\n");
-    assertText(result.get(1), "\n");
-    assertText(result.get(2), "multi-line text.");
-
-    // Empty lines?
-    result = parser.parse("""
-                Text
-                """);
-    assertEquals(1, result.size());
-    assertText(result.get(0), "Text\n");
-  }
-
-  @Test
-  public void canParseSimpleHeadline() {
-    String input = "==Headline==";
-    final MarkupParser parser = new MarkupParser();
-    List<MarkupToken> result = parser.parse(input);
-    assertEquals(1, result.size());
-
-    MarkupToken parseToken = result.getFirst();
-    assertHeadline(parseToken, 2, "Headline");
-  }
-
-  @Test
-  public void canParseLink() {
-    String input = "[[Link]]";
-    final MarkupParser parser = new MarkupParser();
-    final List<MarkupToken> result = parser.parse(input);
-    assertEquals(1, result.size());
-    assertLink(result.get(0), "Link", "Link");
-  }
-
-  @Test
-  public void canParsePipedLink() {
-    String input = "[[Link|Label]]";
-    final MarkupParser parser = new MarkupParser();
-    final List<MarkupToken> result = parser.parse(input);
-    assertEquals(1, result.size());
-    assertLink(result.get(0), "Label", "Link");
-  }
-
-  @Test
-  public void canParseWordEndingLinks() {
-    String input = "[[Link]]here But this is text!";
-    final MarkupParser parser = new MarkupParser();
-    List<MarkupToken> result = parser.parse(input);
-    assertEquals(2, result.size());
-    assertLink(result.get(0), "Linkhere", "Link");
-    assertText(result.get(1), " But this is text!");
-
-    result = parser.parse("[[Link]]. But not text.");
-    assertEquals(2, result.size());
-    assertLink(result.get(0), "Link", "Link");
-    assertText(result.get(1), ". But not text.");
-
-    result = parser.parse("[[Link|Label]], but not text.");
-    assertEquals(2, result.size());
-    assertLink(result.get(0), "Label", "Link");
-    assertText(result.get(1), ", but not text.");
-
-    result = parser.parse("[[Link|Label]], [[Another|Label2]].");
-    assertEquals(4, result.size());
-    assertLink(result.get(0), "Label", "Link");
-    assertText(result.get(1), ", ");
-    assertLink(result.get(2), "Label2", "Another");
-    assertText(result.get(3), ".");
-  }
-
-  @Test
-  public void canParseMacrosWithLinkArgument() {
-    final MarkupParser parser = new MarkupParser();
-    final List<MarkupToken> result = parser.parse("{{Macro|[[Link|Label]]}}");
-    assertEquals(3, result.size());
-    assertText(result.get(0), "{{Macro|");
-    assertLink(result.get(1), "Label", "Link");
-    assertText(result.get(2), "}}");
-  }
 
   @Test
   public void canParseSimpleDocument() {
@@ -150,54 +57,10 @@ class MarkupParserTest {
   public void canParseRealDocument() {
     final MarkupParser parser = new MarkupParser();
     assertTimeoutPreemptively(
-        Duration.ofMillis(2000),
+        Duration.ofMillis(50),
         () -> {
           parser.parse(Fixtures.REAL_PAGE_MARKUP);
         });
-  }
-
-  @Test
-  public void canParseIndent() {
-    final MarkupParser parser = new MarkupParser();
-    List<MarkupToken> result = parser.parse(": Indent Level 1");
-    assertIndent(result.get(0), 1);
-    assertText(result.get(1), " Indent Level 1");
-
-    result = parser.parse(":: Indent Level 2");
-    assertIndent(result.get(0), 2);
-    assertText(result.get(1), " Indent Level 2");
-
-    result = parser.parse("::: Indent Level 3");
-    assertIndent(result.get(0), 3);
-    assertText(result.get(1), " Indent Level 3");
-
-    result = parser.parse(": Another [[Example]]");
-    assertIndent(result.get(0), 1);
-    assertText(result.get(1), " Another ");
-    assertLink(result.get(2), "Example", "Example");
-
-    result = parser.parse(":  With extra whitespace");
-    assertIndent(result.get(0), 1);
-    assertText(result.get(1), "  With extra whitespace");
-
-    result = parser.parse("""
-                : Line 1
-                : Line 2 [[WithLink]]""");
-    assertIndent(result.get(0), 1);
-    assertText(result.get(1), " Line 1\n");
-    assertIndent(result.get(2), 1);
-    assertText(result.get(3), " Line 2 ");
-    assertLink(result.get(4), "WithLink");
-
-    // We mostly encounter indent with a space in between the colon and text,
-    // but these forms are also possible:
-    result = parser.parse(":[[Link]]");
-    assertIndent(result.get(0), 1);
-    assertLink(result.get(1), "Link");
-
-    result = parser.parse("::More");
-    assertIndent(result.get(0), 2);
-    assertText(result.get(1), "More");
   }
 
   public void testVariousOverflowAndUnderflowSituations() {}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTest.java
@@ -65,6 +65,20 @@ class MarkupParserTest {
     assertText(parse.get(3), "\n");
   }
 
+  /**
+   * Previously there were circumstance where our text parser generated empty text tokens, that
+   * would prevent some loops from terminating. Avoid this.
+   */
+  @Test
+  public void regressionTestTerminatesWithoutEmptyText() {
+    assertTimeoutPreemptively(
+        Duration.ofMillis(10),
+        () -> {
+          final List<MarkupToken> result = MarkupParser.parseString("''test''");
+          assertTokens(result, List.of(italic(List.of(text("test")))));
+        });
+  }
+
   @Test
   public void canParseRealDocument() {
     final MarkupParser parser = new MarkupParser();

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTest.java
@@ -33,6 +33,18 @@ class MarkupParserTest {
   }
 
   /**
+   * Some tokens check if they are at the beginning of a line. At the beginning of the line means
+   * either: - after a newline - at the beginning of input So to test if they are at the beginning
+   * of the line is more complex than just checking if the last character was a '\n'.
+   */
+  @Test
+  public void regressionTestNewlineOrBeginningOfInput() {
+    final MarkupParser parser = new MarkupParser();
+    final List<MarkupToken> result = parser.parse(": I'm at the beginning");
+    assertTokens(result, List.of(indent(1), text(" I'm at the beginning")));
+  }
+
+  /**
    * We used to forget to rewind the pointer after consuming characters, which would cause an
    * endless loop here.
    */

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTextTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserTextTest.java
@@ -1,0 +1,42 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("MarkupParser")
+public class MarkupParserTextTest {
+
+  @Test
+  public void canParseSimpleText() {
+    MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse("Hello World!");
+    assertTokensStrict(result, List.of(text("Hello World!")));
+
+    result =
+        parser.parse(
+            """
+                        We can also parse
+
+                        multi-line text.""");
+    assertEquals(3, result.size());
+    assertTokensStrict(
+        result, List.of(text("We can also parse\n"), text("\n"), text("multi-line text.")));
+
+    // Empty lines?
+    result = parser.parse("""
+                Text
+                """);
+    assertTokensStrict(result, List.of(text("Text\n")));
+  }
+
+  @Test
+  public void canParseTextWithColonsAfterOtherMarkup() {
+    MarkupParser parser = new MarkupParser();
+    List<MarkupToken> result = parser.parse("Hello [[World]]: this works great!");
+    assertTokensStrict(result, List.of(text("Hello "), link("World"), text(": this works great!")));
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
@@ -113,6 +113,13 @@ public class TokenAssertions {
     };
   }
 
+  public static Consumer<MarkupToken> italic(List<Consumer<MarkupToken>> inner) {
+    return (MarkupToken token) -> {
+      assertMatchingType(MarkupTokenType.ITALIC, token);
+      assertTokensStrict(((ItalicToken) token).value(), inner);
+    };
+  }
+
   /**
    * Iterate over the provided tokens and see if the supplied matchers match the corresponding
    * token. You can supply more tokens than matchers, but not the other way around. If you want to

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class TokenAssertions {
 
-  private static void assertMatchingType(MarkupTokenType expected, MarkupToken token) {
+  public static void assertMatchingType(MarkupTokenType expected, MarkupToken token) {
     if (!expected.equals(token.getType())) {
       fail(
           String.format(
@@ -55,6 +55,10 @@ public class TokenAssertions {
     }
   }
 
+  public static void assertLink(MarkupToken token, String expectedLabelAndTarget) {
+    assertLink(token, expectedLabelAndTarget, expectedLabelAndTarget);
+  }
+
   public static void assertLink(MarkupToken token, String expectedLabel, String expectedTarget) {
     assertMatchingType(MarkupTokenType.LINK, token);
     final LinkToken linkToken = (LinkToken) token;
@@ -63,6 +67,16 @@ public class TokenAssertions {
     }
     if (!linkToken.target().equals(expectedTarget)) {
       fail(String.format("Expected target '%s' but got '%s'", expectedTarget, linkToken.target()));
+    }
+  }
+
+  public static void assertIndent(MarkupToken token, int expectedLevel) {
+    assertMatchingType(MarkupTokenType.INDENT, token);
+    final IndentToken indentToken = (IndentToken) token;
+    if (indentToken.level() != expectedLevel) {
+      fail(
+          String.format(
+              "Expected indent level '%d' but got '%d'", expectedLevel, indentToken.level()));
     }
   }
 }

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
@@ -2,6 +2,9 @@ package de.zuellich.offlinewiktionary.core.markup;
 
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.List;
+import java.util.function.Consumer;
+
 public class TokenAssertions {
 
   public static void assertMatchingType(MarkupTokenType expected, MarkupToken token) {
@@ -77,6 +80,58 @@ public class TokenAssertions {
       fail(
           String.format(
               "Expected indent level '%d' but got '%d'", expectedLevel, indentToken.level()));
+    }
+  }
+
+  public static void assertTokensStrict(
+      final List<MarkupToken> tokens, final List<Consumer<MarkupToken>> matchers) {
+    if (tokens.size() != matchers.size()) {
+      fail(
+          String.format(
+              "Token count (%d) doesn't match matchers count (%d).",
+              tokens.size(), matchers.size()));
+    }
+
+    assertTokens(tokens, matchers);
+  }
+
+  public static Consumer<MarkupToken> text(String text) {
+    return (MarkupToken token) -> {
+      assertText(token, text);
+    };
+  }
+
+  public static Consumer<MarkupToken> link(String expectedTextAndLabel) {
+    return (MarkupToken token) -> {
+      assertLink(token, expectedTextAndLabel);
+    };
+  }
+
+  public static Consumer<MarkupToken> indent(int level) {
+    return (MarkupToken token) -> {
+      assertIndent(token, level);
+    };
+  }
+
+  /**
+   * Iterate over the provided tokens and see if the supplied matchers match the corresponding
+   * token. You can supply more tokens than matchers, but not the other way around. If you want to
+   * be precise use {@link TokenAssertions#assertTokensStrict(List, List)}
+   */
+  public static void assertTokens(
+      final List<MarkupToken> tokens, final List<Consumer<MarkupToken>> matchers) {
+    if (matchers.size() > tokens.size()) {
+      fail(
+          String.format(
+              "More matchers than tokens. Got %d tokens, but %d matchers.",
+              tokens.size(), matchers.size()));
+    }
+
+    final int min = Math.min(matchers.size(), tokens.size());
+    for (int i = 0; i < min; i++) {
+      final MarkupToken token = tokens.get(i);
+      final Consumer<MarkupToken> matcher = matchers.get(i);
+      matcher.accept(token);
     }
   }
 }


### PR DESCRIPTION
Introduce basic support for indentation and italic markup and reorganize tests related to the `MarkupParser`.