### PR TITLE
Swap spotbugs with error prone

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run tests
       run: ./gradlew test
 
-  spotbugs:
+  compile:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,8 +53,8 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
 
-    - name: Run Spotbugs checks
-      run: ./gradlew spotbugsMain spotbugsTest
+    - name: Compile
+      run: ./gradlew compileJava
 
   spotless:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,8 @@ plugins {
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'com.diffplug.spotless' version '6.25.0'
-    id 'com.github.spotbugs' version '6.0.13'
     id 'net.ltgt.errorprone' version '3.1.0'
-    id("net.ltgt.nullaway") version '2.0.0'
+    id 'net.ltgt.nullaway' version '2.0.0'
 }
 
 group 'de.zuellich'
@@ -46,9 +45,6 @@ dependencies {
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     // end of error prone dependencies
 
-    compileOnly 'com.google.code.findbugs:annotations:3.0.1'
-    testCompileOnly 'com.google.code.findbugs:annotations:3.0.1'
-
     // https://mvnrepository.com/artifact/org.apache.commons/commons-compress
     implementation 'org.apache.commons:commons-compress:1.26.1'
 
@@ -72,6 +68,8 @@ task testParserOnly(type: Test) {
 tasks.compileJava {
     // For now we are happy without proper logging
     options.errorprone.disable("CatchAndPrintStackTrace")
+    // Only really consider null errors for now in CI
+    options.errorprone.error("NullAway")
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'com.diffplug.spotless' version '6.25.0'
     id 'com.github.spotbugs' version '6.0.13'
+    id 'net.ltgt.errorprone' version '3.1.0'
+    id("net.ltgt.nullaway") version '2.0.0'
 }
 
 group 'de.zuellich'
@@ -33,7 +35,17 @@ spotless {
     }
 }
 
+nullaway {
+    annotatedPackages.add("de.zuellich.offlinewiktionary")
+}
+
 dependencies {
+    // Error prone dependencies
+    errorprone("com.google.errorprone:error_prone_core:2.27.1")
+    errorprone "com.uber.nullaway:nullaway:0.10.26"
+    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    // end of error prone dependencies
+
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
     testCompileOnly 'com.google.code.findbugs:annotations:3.0.1'
 
@@ -56,5 +68,11 @@ task testParserOnly(type: Test) {
         includeTags("MarkupParser")
     }
 }
+
+tasks.compileJava {
+    // For now we are happy without proper logging
+    options.errorprone.disable("CatchAndPrintStackTrace")
+}
+
 
 mainClassName = 'de.zuellich.offlinewiktionary.core.WiktionaryApp'

--- a/src/main/java/de/zuellich/offlinewiktionary/core/ImportTask.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/ImportTask.java
@@ -3,7 +3,6 @@ package de.zuellich.offlinewiktionary.core;
 import de.zuellich.offlinewiktionary.core.archive.PageIndexParser;
 import de.zuellich.offlinewiktionary.core.archive.SeekEntry;
 import de.zuellich.offlinewiktionary.core.gui.WiktionaryModel;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,7 +12,6 @@ import javafx.concurrent.Task;
 public class ImportTask extends Task<Void> {
   private final WiktionaryModel model;
 
-  @SuppressFBWarnings(value = "EI2")
   public ImportTask(WiktionaryModel model) {
     this.model = model;
   }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/ImportTask.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/ImportTask.java
@@ -7,7 +7,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.TreeSet;
+import java.util.Set;
 import javafx.concurrent.Task;
 
 public class ImportTask extends Task<Void> {
@@ -28,7 +28,7 @@ public class ImportTask extends Task<Void> {
     updateMessage(String.format("Parsing '%s' ...", targetIndex));
 
     final InputStream in = Files.newInputStream(targetIndex);
-    final TreeSet<SeekEntry> definitions = new PageIndexParser().parse(in);
+    final Set<SeekEntry> definitions = new PageIndexParser().parse(in);
     model.setDefinitions(definitions);
     updateMessage("Done!");
     return null;

--- a/src/main/java/de/zuellich/offlinewiktionary/core/WiktionaryApp.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/WiktionaryApp.java
@@ -23,12 +23,13 @@ public class WiktionaryApp extends Application {
 
   private final WiktionaryModel model = new WiktionaryModel(new WiktionaryReader(null));
   private final TextField search;
-  private WikiTextFlow wikiTextFlow;
+  private final WikiTextFlow wikiTextFlow;
   private final LinkClickHandler linkClickHandler;
 
   public WiktionaryApp() {
     search = new TextField();
     linkClickHandler = new LinkClickHandler();
+    wikiTextFlow = new WikiTextFlow(linkClickHandler);
   }
 
   private String searchHandler(String query) {
@@ -74,8 +75,6 @@ public class WiktionaryApp extends Application {
         });
 
     search.disableProperty().bind(model.isReadyProperty().not());
-
-    wikiTextFlow = new WikiTextFlow(linkClickHandler);
 
     linkClickHandler.onClick(this::displayTerm);
 

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/PageIndexParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/PageIndexParser.java
@@ -3,6 +3,7 @@ package de.zuellich.offlinewiktionary.core.archive;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Scanner;
+import java.util.Set;
 import java.util.TreeSet;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
@@ -18,7 +19,7 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
 public class PageIndexParser {
 
   /** A BZIP2 compressed input stream, will be wrapped in a {@link BufferedInputStream}. */
-  public TreeSet<SeekEntry> parse(InputStream in) {
+  public Set<SeekEntry> parse(InputStream in) {
     final TreeSet<SeekEntry> result = new TreeSet<>();
     try (final BufferedInputStream bin = new BufferedInputStream(in);
         final CompressorInputStream stream =

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/SeekEntry.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/SeekEntry.java
@@ -13,9 +13,10 @@ public record SeekEntry(long bytesToSeek, int articleId, String title)
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    SeekEntry wikiEntry = (SeekEntry) o;
-    return Objects.equals(title, wikiEntry.title);
+    if (!(o instanceof SeekEntry wikiEntry)) return false;
+    return Objects.equals(title, wikiEntry.title)
+        && bytesToSeek == wikiEntry.bytesToSeek
+        && articleId == wikiEntry.articleId;
   }
 
   @Override

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/WikiPageSAXParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/WikiPageSAXParser.java
@@ -1,9 +1,7 @@
 package de.zuellich.offlinewiktionary.core.archive;
 
 import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
-import java.util.HashMap;
-import java.util.Objects;
-import java.util.Stack;
+import java.util.*;
 import org.xml.sax.Attributes;
 import org.xml.sax.helpers.DefaultHandler;
 
@@ -12,10 +10,10 @@ public class WikiPageSAXParser extends DefaultHandler {
 
   private HashMap<Integer, WikiPage> result = new HashMap<>();
 
-  private final Stack<String> lastStartElement = new Stack<>();
+  private final ArrayDeque<String> lastStartElement = new ArrayDeque<>();
   private WikiPage.Builder current = new WikiPage.Builder();
 
-  private StringBuilder elementValue;
+  private StringBuilder elementValue = new StringBuilder();
 
   @Override
   public void startDocument() {
@@ -24,11 +22,7 @@ public class WikiPageSAXParser extends DefaultHandler {
 
   @Override
   public void characters(char[] ch, int start, int length) {
-    if (elementValue == null) {
-      elementValue = new StringBuilder();
-    } else {
-      elementValue.append(ch, start, length);
-    }
+    elementValue.append(ch, start, length);
   }
 
   @Override
@@ -68,12 +62,13 @@ public class WikiPageSAXParser extends DefaultHandler {
       case "page":
         final WikiPage page = current.build();
         result.put(page.id(), page);
+        break;
       default:
         return;
     }
   }
 
-  public HashMap<Integer, WikiPage> getResult() {
+  public Map<Integer, WikiPage> getResult() {
     return new HashMap<>(result);
   }
 }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReader.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReader.java
@@ -8,7 +8,7 @@ import java.io.SequenceInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Map;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -16,24 +16,19 @@ import org.xml.sax.SAXException;
 
 /** Wraps the {@link WikiPageSAXParser} to parse wiki pages from a compressed archive. */
 public class WiktionaryArchiveReader {
-  private SAXParser parser;
+  private final SAXParser parser;
 
-  public WiktionaryArchiveReader() {}
-
-  private SAXParser getParser() {
-    if (parser == null) {
-      SAXParserFactory factory = SAXParserFactory.newInstance();
-      try {
-        parser = factory.newSAXParser();
-      } catch (ParserConfigurationException | SAXException e) {
-        throw new RuntimeException("Something went wrong initializing the SAXParser");
-      }
+  public WiktionaryArchiveReader() {
+    SAXParserFactory factory = SAXParserFactory.newInstance();
+    try {
+      parser = factory.newSAXParser();
+    } catch (ParserConfigurationException | SAXException e) {
+      // TODO add a proper exception
+      throw new RuntimeException("Something went wrong initializing the SAXParser");
     }
-
-    return parser;
   }
 
-  public HashMap<Integer, WikiPage> parse(InputStream toWrap) throws IOException, SAXException {
+  public Map<Integer, WikiPage> parse(InputStream toWrap) throws IOException, SAXException {
     final WikiPageSAXParser wikiPageSAXParser = new WikiPageSAXParser();
     InputStream wrappedStream =
         new SequenceInputStream(
@@ -42,7 +37,7 @@ public class WiktionaryArchiveReader {
                     new ByteArrayInputStream("<root>".getBytes(StandardCharsets.UTF_8)),
                     toWrap,
                     new ByteArrayInputStream("</root>".getBytes(StandardCharsets.UTF_8)))));
-    getParser().parse(wrappedStream, wikiPageSAXParser);
+    parser.parse(wrappedStream, wikiPageSAXParser);
 
     return wikiPageSAXParser.getResult();
   }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryReader.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryReader.java
@@ -6,8 +6,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
@@ -15,14 +16,17 @@ import org.xml.sax.SAXException;
 
 public class WiktionaryReader {
 
-  private final HashMap<Integer, WikiPage> cache = new HashMap<>();
-  private final Path wiktionaryArchive;
+  @Nullable private final Path wiktionaryArchive;
 
-  public WiktionaryReader(Path wiktionaryArchive) {
+  public WiktionaryReader(@Nullable Path wiktionaryArchive) {
     this.wiktionaryArchive = wiktionaryArchive;
   }
 
   public Optional<WikiPage> retrieve(SeekEntry entry) {
+    if (wiktionaryArchive == null) {
+      return Optional.empty();
+    }
+
     long byteOffset = entry.bytesToSeek();
     try (final InputStream in = Files.newInputStream(wiktionaryArchive);
         final BufferedInputStream bin = new BufferedInputStream(in); ) {
@@ -35,7 +39,7 @@ public class WiktionaryReader {
           new CompressorStreamFactory().createCompressorInputStream(bin);
 
       WiktionaryArchiveReader reader = new WiktionaryArchiveReader();
-      final HashMap<Integer, WikiPage> result = reader.parse(stream);
+      final Map<Integer, WikiPage> result = reader.parse(stream);
 
       final WikiPage wikiPage = result.get(entry.articleId());
 

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/LinkClickHandler.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/LinkClickHandler.java
@@ -1,6 +1,5 @@
 package de.zuellich.offlinewiktionary.core.gui;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayDeque;
 import java.util.function.Consumer;
 import javafx.beans.property.BooleanProperty;
@@ -50,9 +49,6 @@ public class LinkClickHandler {
     historyEmptyProperty.set(history.isEmpty());
   }
 
-  @SuppressFBWarnings(
-      value = "EI",
-      justification = "We do want to expose this property for use in JavaFX")
   public BooleanProperty isHistoryEmptyProperty() {
     return historyEmptyProperty;
   }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/LinkClickHandler.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/LinkClickHandler.java
@@ -1,16 +1,17 @@
 package de.zuellich.offlinewiktionary.core.gui;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Stack;
+import java.util.ArrayDeque;
 import java.util.function.Consumer;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javax.annotation.Nullable;
 
 public class LinkClickHandler {
 
-  private String previousTerm = null;
+  @Nullable private String previousTerm = null;
 
-  private final Stack<String> history = new Stack<>();
+  private final ArrayDeque<String> history = new ArrayDeque<>();
 
   private Consumer<String> clickHandler = (_target) -> {};
   private final BooleanProperty historyEmptyProperty = new SimpleBooleanProperty(true);
@@ -33,20 +34,20 @@ public class LinkClickHandler {
   }
 
   public void historyPush(String item) {
-    if (history.empty() || !history.peek().equals(item)) {
+    if (history.isEmpty() || !history.peekFirst().equals(item)) {
       // For now we don't add duplicates to the history, but fire the click handler
-      history.push(item);
-      historyEmptyProperty.set(history.empty());
+      history.addFirst(item);
+      historyEmptyProperty.set(history.isEmpty());
     }
   }
 
   public void historyBack() {
-    if (history.empty()) {
+    if (history.isEmpty()) {
       return;
     }
 
-    this.handle(history.pop(), true);
-    historyEmptyProperty.set(history.empty());
+    this.handle(history.removeFirst(), true);
+    historyEmptyProperty.set(history.isEmpty());
   }
 
   @SuppressFBWarnings(

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
@@ -1,7 +1,6 @@
 package de.zuellich.offlinewiktionary.core.gui;
 
 import de.zuellich.offlinewiktionary.core.markup.*;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Collection;
 import javafx.scene.Node;
@@ -28,7 +27,6 @@ public class WikiTextFlow extends TextFlow {
   }
 
   // If a token type isn't mapped yet, we rather skip it than to render something unintelligible.
-  @SuppressFBWarnings("SF")
   private Collection<Node> tokensToChildren(Collection<MarkupToken> tokens) {
     ArrayList<Node> result = new ArrayList<>(tokens.size());
     for (MarkupToken token : tokens) {

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
@@ -38,6 +38,12 @@ public class WikiTextFlow extends TextFlow {
         case INDENT -> result.add(indentNode((IndentToken) token));
         case ITALIC -> result.addAll(italicNode((ItalicToken) token));
         case TEXT -> result.add(textNode((TextToken) token));
+        case NULL -> {
+          // Ensure we get notified by ErrorProne in case we are missing a case above
+          // but we don't need to do anything for NULL so we do a useless "continue" and
+          // everyone is happy.
+          continue;
+        }
       }
     }
     return result;
@@ -61,18 +67,16 @@ public class WikiTextFlow extends TextFlow {
   private Node linkNode(LinkToken token) {
     final Hyperlink hyperlink = new Hyperlink(token.label());
     hyperlink.setFont(getFont(12));
-    hyperlink.setOnAction(
-        v -> {
-          linkClickHandler.handle(token.target());
-        });
+    hyperlink.setOnAction(v -> linkClickHandler.handle(token.target()));
     return hyperlink;
   }
 
   private Node headingNode(HeadingToken token) {
-    if (token.value().getType() != MarkupTokenType.TEXT) {
-      return new Text();
-    }
     Text result = new Text();
+    if (token.value() == null || token.value().getType() != MarkupTokenType.TEXT) {
+      return result;
+    }
+
     result.setText(((TextToken) token.value()).value());
     result.setFont(getFont(32));
     // TODO have another TextFlow internally to display things like Macros etc?

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/WiktionaryModel.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/WiktionaryModel.java
@@ -4,7 +4,6 @@ import de.zuellich.offlinewiktionary.core.archive.SeekEntry;
 import de.zuellich.offlinewiktionary.core.archive.WiktionaryReader;
 import de.zuellich.offlinewiktionary.core.resolution.AdjacentResolutionStrategy;
 import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.Set;
@@ -21,9 +20,6 @@ public class WiktionaryModel {
     this.wiktionaryReader = reader;
   }
 
-  @SuppressFBWarnings(
-      value = "EI",
-      justification = "We do want to expose this property for use in JavaFX")
   public BooleanProperty isReadyProperty() {
     return isReady;
   }
@@ -49,9 +45,6 @@ public class WiktionaryModel {
     return wiktionaryReader.retrieve(possibleEntry);
   }
 
-  @SuppressFBWarnings(
-      value = "EI",
-      justification = "We do want to expose this property for use in JavaFX")
   public ReadOnlyObjectProperty<Path> indexProperty() {
     return index.getReadOnlyProperty();
   }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/WiktionaryModel.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/WiktionaryModel.java
@@ -7,11 +7,12 @@ import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeSet;
 import javafx.beans.property.*;
 
 public class WiktionaryModel {
-  private TreeSet<SeekEntry> definitions;
+  private TreeSet<SeekEntry> definitions = new TreeSet<>();
   private WiktionaryReader wiktionaryReader;
   private final BooleanProperty isReady = new SimpleBooleanProperty(false);
   private final ReadOnlyObjectWrapper<Path> index = new ReadOnlyObjectWrapper<Path>(null);
@@ -27,7 +28,7 @@ public class WiktionaryModel {
     return isReady;
   }
 
-  public void setDefinitions(TreeSet<SeekEntry> definitions) {
+  public void setDefinitions(Set<SeekEntry> definitions) {
     this.definitions = new TreeSet<>(definitions);
     this.isReady.set(true);
   }

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/HeadingToken.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/HeadingToken.java
@@ -1,6 +1,8 @@
 package de.zuellich.offlinewiktionary.core.markup;
 
-public record HeadingToken(int level, MarkupToken value) implements MarkupToken {
+import javax.annotation.Nullable;
+
+public record HeadingToken(int level, @Nullable MarkupToken value) implements MarkupToken {
   @Override
   public MarkupTokenType getType() {
     return MarkupTokenType.HEADING;

--- a/src/main/java/de/zuellich/offlinewiktionary/core/wiki/WikiPage.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/wiki/WikiPage.java
@@ -1,18 +1,18 @@
 package de.zuellich.offlinewiktionary.core.wiki;
 
 /** Basic data for Wiki pages and a Builder utility for incremental parsing. */
-public record WikiPage(String title, Integer id, String format, String text) {
+public record WikiPage(String title, int id, String format, String text) {
   public static class Builder {
-    private String title;
-    private Integer id;
-    private String format;
-    private String text;
+    private String title = "";
+    private int id;
+    private String format = "";
+    private String text = "";
 
     public void setTitle(String title) {
       this.title = title;
     }
 
-    public void setId(Integer id) {
+    public void setId(int id) {
       this.id = id;
     }
 

--- a/src/test/java/de/zuellich/offlinewiktionary/core/PageIndexParserTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/PageIndexParserTest.java
@@ -28,7 +28,7 @@ class PageIndexParserTest {
     var input = new ByteArrayInputStream(temp.toByteArray());
     var importer = new PageIndexParser();
 
-    final TreeSet<SeekEntry> result = importer.parse(input);
+    final TreeSet<SeekEntry> result = new TreeSet<>(importer.parse(input));
     input.close();
 
     assertEquals(2, result.size());

--- a/src/test/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReaderTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/archive/WiktionaryArchiveReaderTest.java
@@ -6,7 +6,7 @@ import de.zuellich.offlinewiktionary.core.wiki.WikiPage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.Map;
 import javax.xml.parsers.ParserConfigurationException;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
@@ -21,7 +21,7 @@ class WiktionaryArchiveReaderTest {
 
     final WiktionaryArchiveReader wiktionaryArchiveReader = new WiktionaryArchiveReader();
 
-    final HashMap<Integer, WikiPage> result = wiktionaryArchiveReader.parse(inputStream);
+    final Map<Integer, WikiPage> result = wiktionaryArchiveReader.parse(inputStream);
     assertEquals(1, result.size());
     final WikiPage pageResult = result.get(2682);
     assertNotNull(pageResult);
@@ -39,7 +39,7 @@ class WiktionaryArchiveReaderTest {
         new ByteArrayInputStream(Fixtures.CONCATENATED_PAGES.getBytes(StandardCharsets.UTF_8));
 
     final WiktionaryArchiveReader wiktionaryArchiveReader = new WiktionaryArchiveReader();
-    final HashMap<Integer, WikiPage> result = wiktionaryArchiveReader.parse(inputStream);
+    final Map<Integer, WikiPage> result = wiktionaryArchiveReader.parse(inputStream);
 
     assertEquals(2, result.size());
     assertTrue(result.containsKey(6110313));

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/Fixtures.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/Fixtures.java
@@ -1,10 +1,7 @@
 package de.zuellich.offlinewiktionary.core.markup;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 public class Fixtures {
   // From https://en.wiktionary.org/wiki/Frieden
-  @SuppressFBWarnings("HSC")
   public static final String REAL_PAGE_MARKUP =
       """
             {{Siehe auch|[[frieden]]}}


### PR DESCRIPTION
Introduces NullAway in combination with ErrorProne to ensure null-safety. Removes Spotbugs, as some checks overlap and ErrorProne is good enough for our goals.