### PR TITLE
Markup: Add support for bold formatting

### DIFF
--- a/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/gui/WikiTextFlow.java
@@ -5,10 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import javafx.scene.Node;
 import javafx.scene.control.Hyperlink;
-import javafx.scene.text.Font;
-import javafx.scene.text.FontPosture;
-import javafx.scene.text.Text;
-import javafx.scene.text.TextFlow;
+import javafx.scene.text.*;
 
 /** Use JavaFX {@link javafx.scene.text.TextFlow} to display markdown. */
 public class WikiTextFlow extends TextFlow {
@@ -18,6 +15,7 @@ public class WikiTextFlow extends TextFlow {
 
   private final LinkClickHandler linkClickHandler;
   private boolean italicsEnabled = false;
+  private boolean boldEnabled = false;
   private int fontSize = DEFAULT_FONT_SIZE;
 
   public WikiTextFlow(LinkClickHandler linkClickHandler) {
@@ -38,6 +36,7 @@ public class WikiTextFlow extends TextFlow {
         case LINK -> result.add(linkNode((LinkToken) token));
         case HEADING -> result.addAll(headingNode((HeadingToken) token));
         case INDENT -> result.add(indentNode((IndentToken) token));
+        case BOLD -> result.addAll(boldNode((BoldToken) token));
         case ITALIC -> result.addAll(italicNode((ItalicToken) token));
         case TEXT -> result.add(textNode((TextToken) token));
         case NULL -> {
@@ -52,11 +51,26 @@ public class WikiTextFlow extends TextFlow {
   }
 
   private Font getFont() {
-    if (!italicsEnabled) {
+    if (!italicsEnabled && !boldEnabled) {
       return Font.font("System", fontSize);
     }
 
-    return Font.font("System", FontPosture.ITALIC, fontSize);
+    if (italicsEnabled && boldEnabled) {
+      return Font.font("System", FontWeight.BOLD, FontPosture.ITALIC, fontSize);
+    }
+
+    if (italicsEnabled) {
+      return Font.font("System", FontPosture.ITALIC, fontSize);
+    }
+
+    return Font.font("System", FontWeight.BOLD, fontSize);
+  }
+
+  private Collection<Node> boldNode(BoldToken token) {
+    boldEnabled = true;
+    final Collection<Node> nodes = tokensToChildren(token.value());
+    boldEnabled = false;
+    return nodes;
   }
 
   private Collection<Node> italicNode(ItalicToken token) {

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/BoldToken.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/BoldToken.java
@@ -1,0 +1,20 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import java.util.List;
+
+public record BoldToken(List<MarkupToken> value) implements MarkupToken {
+
+  public BoldToken(List<MarkupToken> value) {
+    this.value = List.copyOf(value);
+  }
+
+  @Override
+  public MarkupTokenType getType() {
+    return MarkupTokenType.BOLD;
+  }
+
+  @Override
+  public List<MarkupToken> value() {
+    return List.copyOf(this.value);
+  }
+}

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 public class MarkupParser {
   /**
    * Mixing bold and italic can lead to situations where we fail to parse the content of the tokens
-   * correctly and would never return a result. Using the level below we can implement an eager
+   * correctly and would never return a result. Using the variable below we can implement a lazy
    * parsing, where we rather close an existing token than start a new one.
    */
   private int boldItalicLevel = 0;

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupParser.java
@@ -8,7 +8,7 @@ public class MarkupParser {
   /**
    * Mixing bold and italic can lead to situations where we fail to parse the content of the tokens
    * correctly and would never return a result. Using the variable below we can implement a lazy
-   * parsing, where we rather close an existing token than start a new one.
+   * approach, where we rather close an existing token than start a new one.
    */
   private int boldItalicLevel = 0;
 

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupToken.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupToken.java
@@ -9,6 +9,7 @@ public interface MarkupToken {
       switch (token.getType()) {
         case TEXT -> result.append(((TextToken) token).value());
         case ITALIC -> result.append(toPlainText(((ItalicToken) token).value()));
+        case BOLD -> result.append(toPlainText(((BoldToken) token).value()));
         case HEADING -> result.append(toPlainText(((HeadingToken) token).value()));
         case LINK -> result.append(toPlainText(((LinkToken) token).labelValue()));
         case INDENT -> result.append("\t".repeat(Math.min(((IndentToken) token).level(), 10)));

--- a/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupTokenType.java
+++ b/src/main/java/de/zuellich/offlinewiktionary/core/markup/MarkupTokenType.java
@@ -1,6 +1,7 @@
 package de.zuellich.offlinewiktionary.core.markup;
 
 public enum MarkupTokenType {
+  BOLD,
   HEADING,
   INDENT,
   ITALIC,

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserBoldTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserBoldTest.java
@@ -1,0 +1,32 @@
+package de.zuellich.offlinewiktionary.core.markup;
+
+import static de.zuellich.offlinewiktionary.core.markup.TokenAssertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("MarkupParser")
+public class MarkupParserBoldTest {
+
+  @Test
+  public void canParseSimpleBoldText() {
+    final List<MarkupToken> markupTokens = MarkupParser.parseString("'''Hello World'''");
+    assertTokensStrict(markupTokens, bold(text("Hello World")));
+  }
+
+  @Test
+  public void canMixWithItalics() {
+    final List<MarkupToken> markupTokens = MarkupParser.parseString("'''''I''talic And Bold'''");
+    assertTokensStrict(markupTokens, bold(List.of(italic(text("I")), text("talic And Bold"))));
+  }
+
+  @Test
+  public void canCombineWithLinks() {
+    List<MarkupToken> markupTokens = MarkupParser.parseString("'''[[Link]]'''");
+    assertTokensStrict(markupTokens, bold(link("Link")));
+
+    markupTokens = MarkupParser.parseString("[[Link|'''Bold''']]");
+    assertTokensStrict(markupTokens, link("Link", bold(text("Bold"))));
+  }
+}

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserItalicTest.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/MarkupParserItalicTest.java
@@ -45,4 +45,11 @@ public class MarkupParserItalicTest {
             italic(text("more")),
             text(" italics.")));
   }
+
+  @Test
+  public void canCombineWithBold() {
+    // NOTE: this test emphasis italics wrapping bold, there are separate tests just for bold
+    final List<MarkupToken> tokens = MarkupParser.parseString("'''''H'''ere comes bold''");
+    assertTokensStrict(tokens, italic(List.of(bold(text("H")), text("ere comes bold"))));
+  }
 }

--- a/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
+++ b/src/test/java/de/zuellich/offlinewiktionary/core/markup/TokenAssertions.java
@@ -73,6 +73,18 @@ public class TokenAssertions {
     assertTokensStrict(List.of(token), List.of(matcher));
   }
 
+  public static Consumer<MarkupToken> bold(List<Consumer<MarkupToken>> expectedValue) {
+    return (MarkupToken token) -> {
+      assertMatchingType(MarkupTokenType.BOLD, token);
+      List<MarkupToken> value = ((BoldToken) token).value();
+      assertTokensStrict(value, expectedValue);
+    };
+  }
+
+  public static Consumer<MarkupToken> bold(Consumer<MarkupToken> expectedValue) {
+    return bold(List.of(expectedValue));
+  }
+
   public static Consumer<MarkupToken> text(String text) {
     return (MarkupToken token) -> {
       assertText(token, text);


### PR DESCRIPTION
Allows to combine bold and italics to support even more pages from the Wiktionary archives.